### PR TITLE
refacto-routing to main

### DIFF
--- a/src/app/pages/spells/spells.route.ts
+++ b/src/app/pages/spells/spells.route.ts
@@ -1,0 +1,16 @@
+import {Routes} from "@angular/router";
+
+const spellsRoutes: Routes = [
+    {
+        path: 'spells',
+        children: [
+            {
+                path: '',
+                pathMatch: 'full',
+                loadComponent: () => import('./spells.page').then(c => c.SpellsPage),
+            },
+        ]
+    }
+];
+
+export default spellsRoutes;

--- a/src/app/pages/tabs/tabs.routes.ts
+++ b/src/app/pages/tabs/tabs.routes.ts
@@ -1,5 +1,7 @@
 import { Routes } from '@angular/router';
 import { TabsPage } from './tabs.page';
+import wizardsRoutes from "../wizards/wizards.route";
+import spellsRoutes from "../spells/spells.route";
 
 export const tabsRoutes: Routes = [
   {
@@ -11,14 +13,8 @@ export const tabsRoutes: Routes = [
         redirectTo: 'wizards',
         pathMatch: 'full',
       },
-      {
-        path: '',
-        loadChildren: () => import('../wizards/wizards.route')
-      },
-      {
-        path: 'spells',
-        loadComponent: () => import('../spells/spells.page').then(c => c.SpellsPage)
-      },
+        ...wizardsRoutes,
+        ...spellsRoutes,
     ],
   },
 ];

--- a/src/app/pages/wizards/wizards.route.ts
+++ b/src/app/pages/wizards/wizards.route.ts
@@ -1,6 +1,6 @@
 import {Routes} from "@angular/router";
 
-const routes: Routes = [
+const wizardsRoutes: Routes = [
     {
         path: 'wizards',
         children: [
@@ -17,4 +17,4 @@ const routes: Routes = [
     }
 ];
 
-export default routes;
+export default wizardsRoutes;


### PR DESCRIPTION
routing: centralisation des routes spells et wizard dans tabsRoutes

Objectif : rendre le routing de l'application maintenable dans le cas ou la vue spells-details vient a être demandé.